### PR TITLE
fix: for_each was being iterating over a `cty.DynamicPseudoType` keys

### DIFF
--- a/pkg/iac/adapters/terraform/aws/iam/roles_test.go
+++ b/pkg/iac/adapters/terraform/aws/iam/roles_test.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/aquasecurity/iamgo"
@@ -349,5 +350,93 @@ resource "aws_iam_role_policy_attachment" "test" {
 			})
 			testutil.AssertDefsecEqual(t, test.expected, adapted)
 		})
+	}
+}
+
+func Test_attachmentCountForEachMap(t *testing.T) {
+	source := `
+locals {
+  platform_role_principals = {
+    lambda    = "lambda.amazonaws.com"
+    ecs-tasks = "ecs-tasks.amazonaws.com"
+  }
+}
+
+data "aws_iam_policy_document" "platform_role_assume_policy" {
+  for_each = local.platform_role_principals
+
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = [each.value]
+    }
+  }
+}
+
+resource "aws_iam_role" "platform_role" {
+  for_each           = local.platform_role_principals
+  name               = "platform-${each.key}"
+  assume_role_policy = data.aws_iam_policy_document.platform_role_assume_policy[each.key].json
+}
+
+locals {
+  platform_roles = {
+    for role_key, role_res in aws_iam_role.platform_role :
+    role_key => {
+      role = role_res.name
+    }
+  }
+}
+
+data "aws_iam_policy_document" "administrative_policy_doc" {
+  statement {
+    resources = ["*"]
+    actions   = ["Tag:GetResources", "Tag:TagResources", "Tag:UntagResources"]
+  }
+}
+
+resource "aws_iam_policy" "administrative_policy" {
+  name   = "administrative-policy"
+  policy = data.aws_iam_policy_document.administrative_policy_doc.json
+}
+
+resource "aws_iam_role_policy_attachment" "administrative_policy_attachment" {
+  for_each   = local.platform_roles
+  role       = each.value.role
+  policy_arn = aws_iam_policy.administrative_policy.arn
+}
+`
+
+	modules := tftestutil.CreateModulesFromSource(t, source, ".tf")
+	attachments := modules.GetResourcesByType("aws_iam_role_policy_attachment")
+
+	var attachmentRefs []string
+	for _, a := range attachments {
+		attachmentRefs = append(attachmentRefs, a.Reference().String())
+	}
+
+	// Expected attachment keys (they will include the map key)
+	expectedCount := 2
+
+	sort.Strings(attachmentRefs)
+
+	if len(attachments) != expectedCount {
+		t.Fatalf("expected %d policy attachments, got %d: %v", expectedCount, len(attachments), attachmentRefs)
+	}
+
+	// Additional sanity check: ensure both map keys appear once
+	hasLambda := false
+	hasEcs := false
+	for _, ref := range attachmentRefs {
+		if strings.Contains(ref, "lambda") {
+			hasLambda = true
+		}
+		if strings.Contains(ref, "ecs-tasks") {
+			hasEcs = true
+		}
+	}
+	if !hasLambda || !hasEcs {
+		t.Fatalf("expected attachment refs to include both lambda and ecs-tasks keys, got %v", attachmentRefs)
 	}
 }

--- a/pkg/iac/adapters/terraform/aws/iam/roles_test.go
+++ b/pkg/iac/adapters/terraform/aws/iam/roles_test.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -411,6 +412,27 @@ resource "aws_iam_role_policy_attachment" "administrative_policy_attachment" {
 	modules := tftestutil.CreateModulesFromSource(t, source, ".tf")
 	attachments := modules.GetResourcesByType("aws_iam_role_policy_attachment")
 
+	// Debug output - let's see what's actually happening
+	fmt.Printf("DEBUG: Total resources found: %d\n", len(attachments))
+	for i, attachment := range attachments {
+		fmt.Printf("DEBUG: Attachment %d: %s\n", i, attachment.Reference().String())
+		fmt.Printf("  - FullName: %s\n", attachment.FullName())
+		fmt.Printf("  - TypeLabel: %s\n", attachment.TypeLabel())
+		fmt.Printf("  - NameLabel: %s\n", attachment.NameLabel())
+		if key := attachment.Reference().RawKey(); !key.IsNull() && key.IsKnown() {
+			fmt.Printf("  - Key: %s (%s)\n", key.GoString(), key.Type().GoString())
+		}
+	}
+
+	// Also check all blocks to see what's available
+	allBlocks := modules.GetBlocks()
+	fmt.Printf("\nDEBUG: All blocks:\n")
+	for i, block := range allBlocks {
+		if strings.Contains(block.Reference().String(), "platform") {
+			fmt.Printf("  Block %d: %s (%s)\n", i, block.Reference().String(), block.Type())
+		}
+	}
+
 	var attachmentRefs []string
 	for _, a := range attachments {
 		attachmentRefs = append(attachmentRefs, a.Reference().String())
@@ -438,5 +460,91 @@ resource "aws_iam_role_policy_attachment" "administrative_policy_attachment" {
 	}
 	if !hasLambda || !hasEcs {
 		t.Fatalf("expected attachment refs to include both lambda and ecs-tasks keys, got %v", attachmentRefs)
+	}
+}
+
+func Test_simpleForEachReference(t *testing.T) {
+	// Test 1: Simple for_each with direct reference - this should work
+	source1 := `
+locals {
+  roles = {
+    lambda    = "lambda.amazonaws.com"
+    ecs-tasks = "ecs-tasks.amazonaws.com"
+  }
+}
+
+resource "aws_iam_role" "platform_role" {
+  for_each = local.roles
+  name     = "platform-${each.key}"
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  for_each = aws_iam_role.platform_role
+  role     = each.value.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}`
+
+	modules1 := tftestutil.CreateModulesFromSource(t, source1, ".tf")
+	attachments1 := modules1.GetResourcesByType("aws_iam_role_policy_attachment")
+
+	fmt.Printf("Test 1 - Direct reference - Attachments found: %d\n", len(attachments1))
+	for i, attachment := range attachments1 {
+		fmt.Printf("  %d: %s\n", i, attachment.Reference().String())
+		if key := attachment.Reference().RawKey(); !key.IsNull() && key.IsKnown() {
+			fmt.Printf("     Key: %s\n", key.GoString())
+		}
+	}
+
+	// Test 2: for_each with computed local (the problematic case)
+	source2 := `
+locals {
+  role_principals = {
+    lambda    = "lambda.amazonaws.com"
+    ecs-tasks = "ecs-tasks.amazonaws.com"
+  }
+}
+
+resource "aws_iam_role" "platform_role" {
+  for_each = local.role_principals
+  name     = "platform-${each.key}"
+}
+
+locals {
+  platform_roles = {
+    for role_key, role_res in aws_iam_role.platform_role :
+    role_key => {
+      role = role_res.name
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  for_each = local.platform_roles
+  role     = each.value.role
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}`
+
+	modules2 := tftestutil.CreateModulesFromSource(t, source2, ".tf")
+	attachments2 := modules2.GetResourcesByType("aws_iam_role_policy_attachment")
+
+	fmt.Printf("\nTest 2 - Computed local - Attachments found: %d\n", len(attachments2))
+	for i, attachment := range attachments2 {
+		fmt.Printf("  %d: %s\n", i, attachment.Reference().String())
+		if key := attachment.Reference().RawKey(); !key.IsNull() && key.IsKnown() {
+			fmt.Printf("     Key: %s\n", key.GoString())
+		}
+	}
+
+	// Let's also examine the local.platform_roles value
+	allBlocks := modules2.GetBlocks()
+	for _, block := range allBlocks {
+		if block.Type() == "locals" {
+			for _, attr := range block.GetAttributes() {
+				if attr.Name() == "platform_roles" {
+					fmt.Printf("\nlocal.platform_roles value: %s\n", attr.Value().GoString())
+					fmt.Printf("local.platform_roles type: %s\n", attr.Value().Type().GoString())
+				}
+			}
+		}
 	}
 }

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"context"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -2403,7 +2404,7 @@ untyped = "zzz"
 	)
 
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, err := parser.EvaluateAll(context.TODO())
 	require.NoError(t, err)
 
 	resources := modules.GetResourcesByType("test")


### PR DESCRIPTION
for_each was being evaluated before the locals were evaluated which
was making it iterate over a `cty.DynamicPseudoType` which meant it
was iterating over the keys of a single instance resource instead of
the values of the for_each.

See the tests added for proof of the problem.   I've left the debug log
lines in because they were useful fixing the issue but I can remove them
if we don't want them.

Upstream PR is here:
https://github.com/aquasecurity/trivy/pull/9156