### PR TITLE
fix: resolve path-based functions relative to the project root

### DIFF
--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -59,8 +59,15 @@ func newEvaluator(
 ) *evaluator {
 
 	// create a context to store variables and make functions available
+	//
+	// Path-based functions (file, fileexists, fileset, ...) resolve their
+	// arguments relative to the project root, matching Terraform, which
+	// resolves them relative to the working directory rather than to the
+	// module. Using modulePath here instead would double-count the module
+	// prefix for the idiomatic file("${path.module}/x"), since path.module is
+	// itself project-root relative (see below).
 	ctx := tfcontext.NewContext(&hcl.EvalContext{
-		Functions: Functions(target, modulePath),
+		Functions: Functions(target, projectRootPath),
 	}, nil)
 
 	// these variables are made available by terraform to each module


### PR DESCRIPTION
## Problem

`file()`, `fileexists()`, `fileset()` and the other path-based functions resolve their arguments relative to `modulePath`, while `path.module` is *itself* project-root relative. Both come from the same string in `newEvaluator`:

```go
Functions: Functions(target, modulePath),
...
ctx.SetByDot(cty.StringVal(modulePath), "path.module")
```

The two conventions compose, so the idiomatic form inside a non-root module

```hcl
file("${path.module}/data.yml")
```

resolves `<module>/<module>/data.yml`, misses, and returns null.

Probing the builtins from inside a nested module `moda` makes the double-prefix explicit:

| expression | scanning the parent | scanning `moda` directly |
| --- | --- | --- |
| `path.module` | `"moda"` | `"."` |
| `fileexists("data.yml")` | `true` | `true` |
| `fileexists("${path.module}/data.yml")` | **`false`** | `true` |
| `file("${path.module}/data.yml")` | **`null`** | contents |

The bare `fileexists("data.yml")` being true in both columns shows the file-resolution base is already the module directory; only the `path.module` prefix pushes it out of range.

## Impact

The failure is silent, and the severity depends on where the value lands. When it feeds a `for_each`, every resource keyed off it is dropped from the graph with no error — for a data-driven module that is usually the entire module:

```hcl
# root/main.tf
module "a" { source = "./moda" }

# root/moda/main.tf
locals {
  items = yamldecode(file("${path.module}/data.yml"))
}

resource "aws_s3_bucket" "this" {
  for_each = local.items
  bucket   = each.value.name
}
```

Scanning `root/` yields only the `module.a` call-site arguments and `locals.items: null`. Scanning `root/moda/` directly yields the fully expanded buckets. `terraform validate` and `tofu validate` both succeed on the configuration.

## Fix

Terraform resolves path-based functions relative to the working directory rather than the module — which is exactly *why* the `path.module` prefix is idiomatic. This changes the base directory to `projectRootPath` to match, leaving `path.module` alone.

- `file("${path.module}/x")` in a non-root module — fixed.
- `file("x")` in a non-root module — now resolves from the project root. This is a deliberate behavior change, and it matches Terraform, where the bare form does not read the module's own directory either.
- Root module — unaffected, since `projectRootPath == modulePath` there.

## Testing

Verified against the downstream consumer, [cloud-custodian/tfparse](https://github.com/cloud-custodian/tfparse) (which pins this fork):

- its full suite passes, including `test_funcs`, the existing coverage of these builtins — every `file()`/`fileset()`/`fileexists()` call in that fixture corpus is in a root module, so it is unaffected either way
- a new regression fixture exercising the nested-module case goes from `KeyError` (resource absent) to passing
- the downstream `c7n_left` suite is unchanged at 84 passed / 3 skipped / 1 xfailed

Reported downstream as cloud-custodian/tfparse#282. Happy to submit the same patch to `aquasecurity/trivy` — it reproduces there too.
