### PR TITLE
fix: honor the Path() escape hatch when sandboxing file functions

### DIFF
--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
@@ -408,6 +408,10 @@ func readFileBytes(target fs.FS, baseDir, path string) ([]byte, error) {
 		}
 		return nil, err
 	}
+	// The handle must be released explicitly: on Windows an open handle blocks
+	// deletion of the underlying file. Harmless for trivy's own in-memory
+	// mapfs, but openFile is given a real OS-backed FS by embedders.
+	defer f.Close()
 
 	src, err := io.ReadAll(f)
 	if err != nil {

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"unicode/utf8"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -262,10 +261,7 @@ func MakeFileSetFunc(target fs.FS, baseDir string) function.Function {
 
 			// If we got an absolute path, make it relative to an FS that can handle it.
 			if filepath.IsAbs(path) {
-				rootpath := "/"
-				if runtime.GOOS == "windows" {
-					rootpath = filepath.VolumeName(path)
-				}
+				rootpath := volumeRoot(path)
 				useTarget = os.DirFS(rootpath)
 				if relpath, err := filepath.Rel(rootpath, path); err == nil {
 					path = relpath
@@ -451,4 +447,20 @@ func expandHome(path string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, path[1:]), nil
+}
+
+// volumeRoot returns the rooted directory that path lives under, suitable for
+// both os.DirFS and as a filepath.Rel base.
+//
+// On Windows filepath.VolumeName yields a volume without a trailing separator
+// ("C:", or `\\server\share` for UNC). Those are drive-relative rather than
+// rooted, so os.DirFS resolves them against the process working directory and
+// filepath.Rel refuses them outright ("can't make C:\dir relative to C:").
+// Appending the separator turns them into the volume root. On Unix
+// VolumeName is always empty, so this is just "/".
+func volumeRoot(path string) string {
+	if vol := filepath.VolumeName(path); vol != "" {
+		return vol + string(filepath.Separator)
+	}
+	return string(filepath.Separator)
 }

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
@@ -78,3 +78,27 @@ func TestExpandHome(t *testing.T) {
 		})
 	}
 }
+
+func TestVolumeRoot(t *testing.T) {
+	// The absolute-path branch of MakeFileSetFunc uses volumeRoot both as an
+	// os.DirFS root and as a filepath.Rel base, so the result has to be rooted
+	// and has to be a valid base for any absolute path on the same volume.
+	// Expressing it as an invariant keeps the check meaningful on every
+	// platform; a bare volume name ("C:") satisfies neither.
+	paths := []string{
+		filepath.Join(t.TempDir(), "cfg", "files"),
+		string(filepath.Separator),
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			root := volumeRoot(path)
+
+			assert.True(t, filepath.IsAbs(root), "volumeRoot(%q) = %q is not rooted", path, root)
+
+			rel, err := filepath.Rel(root, path)
+			require.NoError(t, err, "volumeRoot(%q) = %q is not a usable Rel base", path, root)
+			assert.False(t, filepath.IsAbs(rel), "%q should be relative to %q", rel, root)
+		})
+	}
+}

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
@@ -85,10 +85,11 @@ func TestVolumeRoot(t *testing.T) {
 	// and has to be a valid base for any absolute path on the same volume.
 	// Expressing it as an invariant keeps the check meaningful on every
 	// platform; a bare volume name ("C:") satisfies neither.
-	paths := []string{
-		filepath.Join(t.TempDir(), "cfg", "files"),
-		string(filepath.Separator),
-	}
+	// Both inputs must be absolute paths, which is what the caller has already
+	// established. A bare separator does not qualify on Windows, where "\\" is
+	// rooted but drive-relative, so derive the second case from the first.
+	nested := filepath.Join(t.TempDir(), "cfg", "files")
+	paths := []string{nested, volumeRoot(nested)}
 
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {

--- a/pkg/iac/scanners/terraform/parser/functions.go
+++ b/pkg/iac/scanners/terraform/parser/functions.go
@@ -19,7 +19,7 @@ func Functions(target fs.FS, baseDir string) map[string]function.Function {
 	// Use a sandboxed FS without underlyingRoot for file functions to prevent
 	// path traversal above the scan root via mapfs's underlying OS fallback.
 	//
-	// An FS exposing Path() is the escape hatch honoured by MakeFileSetFunc:
+	// An FS exposing Path() is the escape hatch honored by MakeFileSetFunc:
 	// an embedder supplying one has deliberately opted out of the jail so its
 	// modules can reference paths outside the scan root, so leave it in place
 	// rather than substituting an empty in-memory FS.

--- a/pkg/iac/scanners/terraform/parser/functions.go
+++ b/pkg/iac/scanners/terraform/parser/functions.go
@@ -18,10 +18,17 @@ import (
 func Functions(target fs.FS, baseDir string) map[string]function.Function {
 	// Use a sandboxed FS without underlyingRoot for file functions to prevent
 	// path traversal above the scan root via mapfs's underlying OS fallback.
-	if mfs, ok := target.(*mapfs.FS); ok {
-		target = mfs.Sandboxed()
-	} else {
-		target = mapfs.New()
+	//
+	// An FS exposing Path() is the escape hatch honoured by MakeFileSetFunc:
+	// an embedder supplying one has deliberately opted out of the jail so its
+	// modules can reference paths outside the scan root, so leave it in place
+	// rather than substituting an empty in-memory FS.
+	if _, escapes := target.(interface{ Path() string }); !escapes {
+		if mfs, ok := target.(*mapfs.FS); ok {
+			target = mfs.Sandboxed()
+		} else {
+			target = mapfs.New()
+		}
 	}
 	return map[string]function.Function{
 		"abs":              stdlib.AbsoluteFunc,

--- a/pkg/iac/scanners/terraform/parser/functions.go
+++ b/pkg/iac/scanners/terraform/parser/functions.go
@@ -19,16 +19,16 @@ func Functions(target fs.FS, baseDir string) map[string]function.Function {
 	// Use a sandboxed FS without underlyingRoot for file functions to prevent
 	// path traversal above the scan root via mapfs's underlying OS fallback.
 	//
-	// An FS exposing Path() is the escape hatch honored by MakeFileSetFunc:
-	// an embedder supplying one has deliberately opted out of the jail so its
-	// modules can reference paths outside the scan root, so leave it in place
-	// rather than substituting an empty in-memory FS.
-	if _, escapes := target.(interface{ Path() string }); !escapes {
-		if mfs, ok := target.(*mapfs.FS); ok {
-			target = mfs.Sandboxed()
-		} else {
-			target = mapfs.New()
-		}
+	// A *mapfs.FS is always sandboxed: its underlyingRoot fallback is the
+	// traversal vector being closed here. Any other FS exposing Path() is the
+	// escape hatch honored by MakeFileSetFunc — an embedder supplying one has
+	// deliberately opted out of the jail so its modules can reference paths
+	// outside the scan root, so leave it in place rather than substituting an
+	// empty in-memory FS.
+	if mfs, ok := target.(*mapfs.FS); ok {
+		target = mfs.Sandboxed()
+	} else if _, escapes := target.(interface{ Path() string }); !escapes {
+		target = mapfs.New()
 	}
 	return map[string]function.Function{
 		"abs":              stdlib.AbsoluteFunc,

--- a/pkg/iac/scanners/terraform/parser/functions_test.go
+++ b/pkg/iac/scanners/terraform/parser/functions_test.go
@@ -100,7 +100,7 @@ func TestFunctions_FileExists(t *testing.T) {
 }
 
 // pathFS resolves names against a real directory and exposes that directory
-// through Path(), the escape-hatch convention MakeFileSetFunc already honours
+// through Path(), the escape-hatch convention MakeFileSetFunc already honors
 // for embedders that intentionally opt out of the sandbox.
 type pathFS struct{ root string }
 

--- a/pkg/iac/scanners/terraform/parser/functions_test.go
+++ b/pkg/iac/scanners/terraform/parser/functions_test.go
@@ -98,3 +98,52 @@ func TestFunctions_FileExists(t *testing.T) {
 		})
 	}
 }
+
+// pathFS resolves names against a real directory and exposes that directory
+// through Path(), the escape-hatch convention MakeFileSetFunc already honours
+// for embedders that intentionally opt out of the sandbox.
+type pathFS struct{ root string }
+
+func (p pathFS) Open(name string) (fs.File, error) {
+	return os.Open(filepath.Join(p.root, filepath.FromSlash(name)))
+}
+
+func (p pathFS) Path() string { return p.root }
+
+func TestFunctions_PathEscapeHatch(t *testing.T) {
+	// An embedder supplying an FS with a Path() escape hatch has deliberately
+	// opted out of the sandbox, so Functions must leave that FS in place
+	// instead of substituting an empty in-memory one.
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "cfg", "files"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "cfg", "userdata.sh"), []byte("#!/bin/bash"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "cfg", "files", "x.py"), []byte("x"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "lambdas"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "lambdas", "main.go"), []byte("package main"), 0o600))
+
+	fns := Functions(pathFS{root: root}, "cfg")
+
+	t.Run("file", func(t *testing.T) {
+		val, err := fns["file"].Call([]cty.Value{cty.StringVal("userdata.sh")})
+		require.NoError(t, err)
+		assert.Equal(t, "#!/bin/bash", val.AsString())
+	})
+
+	t.Run("fileexists", func(t *testing.T) {
+		val, err := fns["fileexists"].Call([]cty.Value{cty.StringVal("userdata.sh")})
+		require.NoError(t, err)
+		assert.Equal(t, cty.True, val)
+	})
+
+	t.Run("fileset", func(t *testing.T) {
+		val, err := fns["fileset"].Call([]cty.Value{cty.StringVal("files"), cty.StringVal("*.py")})
+		require.NoError(t, err)
+		assert.Equal(t, cty.SetVal([]cty.Value{cty.StringVal("x.py")}), val)
+	})
+
+	t.Run("fileset above the base dir", func(t *testing.T) {
+		val, err := fns["fileset"].Call([]cty.Value{cty.StringVal("../lambdas"), cty.StringVal("*.go")})
+		require.NoError(t, err)
+		assert.Equal(t, cty.SetVal([]cty.Value{cty.StringVal("main.go")}), val)
+	})
+}

--- a/pkg/iac/scanners/terraform/parser/functions_test.go
+++ b/pkg/iac/scanners/terraform/parser/functions_test.go
@@ -101,14 +101,35 @@ func TestFunctions_FileExists(t *testing.T) {
 
 // pathFS resolves names against a real directory and exposes that directory
 // through Path(), the escape-hatch convention MakeFileSetFunc already honors
-// for embedders that intentionally opt out of the sandbox.
-type pathFS struct{ root string }
-
-func (p pathFS) Open(name string) (fs.File, error) {
-	return os.Open(filepath.Join(p.root, filepath.FromSlash(name)))
+// for embedders that intentionally opt out of the sandbox. Unlike mapfs it
+// hands out real OS handles, so it also counts them: a handle left open blocks
+// deletion of the file on Windows.
+type pathFS struct {
+	root   string
+	opened int
+	closed int
 }
 
-func (p pathFS) Path() string { return p.root }
+func (p *pathFS) Open(name string) (fs.File, error) {
+	f, err := os.Open(filepath.Join(p.root, filepath.FromSlash(name)))
+	if err != nil {
+		return nil, err
+	}
+	p.opened++
+	return &trackedFile{File: f, fsys: p}, nil
+}
+
+func (p *pathFS) Path() string { return p.root }
+
+type trackedFile struct {
+	fs.File
+	fsys *pathFS
+}
+
+func (f *trackedFile) Close() error {
+	f.fsys.closed++
+	return f.File.Close()
+}
 
 func TestFunctions_PathEscapeHatch(t *testing.T) {
 	// An embedder supplying an FS with a Path() escape hatch has deliberately
@@ -121,7 +142,8 @@ func TestFunctions_PathEscapeHatch(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "lambdas"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "lambdas", "main.go"), []byte("package main"), 0o600))
 
-	fns := Functions(pathFS{root: root}, "cfg")
+	fsys := &pathFS{root: root}
+	fns := Functions(fsys, "cfg")
 
 	t.Run("file", func(t *testing.T) {
 		val, err := fns["file"].Call([]cty.Value{cty.StringVal("userdata.sh")})
@@ -145,5 +167,10 @@ func TestFunctions_PathEscapeHatch(t *testing.T) {
 		val, err := fns["fileset"].Call([]cty.Value{cty.StringVal("../lambdas"), cty.StringVal("*.go")})
 		require.NoError(t, err)
 		assert.Equal(t, cty.SetVal([]cty.Value{cty.StringVal("main.go")}), val)
+	})
+
+	t.Run("no leaked handles", func(t *testing.T) {
+		require.Positive(t, fsys.opened, "expected the subtests above to have opened files")
+		assert.Equal(t, fsys.opened, fsys.closed, "file functions leaked %d handle(s)", fsys.opened-fsys.closed)
 	})
 }


### PR DESCRIPTION
## Problem

Upstream v0.74.0 hardened `Functions()` against path traversal above the scan root:

```go
if mfs, ok := target.(*mapfs.FS); ok {
	target = mfs.Sandboxed()
} else {
	target = mapfs.New()   // an EMPTY in-memory FS
}
```

That runs one layer *above* the `interface{ Path() string }` escape hatch this fork has carried since #1, so it silently defeats it. An embedder that supplies its own `fs.FS` — [cloud-custodian/tfparse](https://github.com/cloud-custodian/tfparse) passes a `relativeResolveFs`, whose entire purpose is to resolve module-relative paths that lead outside the FS root — now gets an empty filesystem, and every path-based builtin returns null or empty with no error surfaced.

Isolated against tfparse's FS, same filesystem both ways:

```
DIRECT  file(): cty.StringVal("test\n\n")               # funcs.MakeFileFunc
VIA-MAP file(): NilVal, "no file exists at readme.md"   # through parser.Functions
```

Switching the embedder to a `*mapfs.FS` is not a way out either: `Sandboxed()` drops `underlyingRoot`, which is exactly what permits the `..` and absolute paths those consumers rely on.

## Impact

Silent, and severe where the value feeds a `for_each` — the same failure mode described in #17. Downstream, `tfparse`'s `test_funcs` regressed to:

| | expected | v0.74.0 merge |
| --- | --- | --- |
| `file("${path.module}/readme.md")` | `"test\n\n"` | `null` |
| `fileexists("${path.module}/readme.md")` | `true` | `false` |
| `fileset("files", "*.py")` | `["x.py", "y.py"]` | `[]` |
| `fileset("${path.module}/../lambdas/*/", "main.go")` | `["abc", "xyz"]` | `[]` |

## Fix

Recognise the same `interface{ Path() string }` that `MakeFileSetFunc` already keys off, and leave such an FS in place. Exposing `Path()` is an explicit opt-out of the jail, so this narrows the hardening only for callers that asked for it.

A plain `fs.FS` with no escape hatch is still replaced with an empty `mapfs.New()` — upstream's `TestFunctions_File_UnknownFSType` covers that and still passes, as do the traversal cases in `TestFunctions_File` / `TestFunctions_FileExists`.

## Testing

- New `TestFunctions_PathEscapeHatch` covers `file`, `fileexists`, `fileset`, and `fileset` above the base dir through a `Path()`-exposing FS. Fails before the change, passes after.
- `go test ./pkg/iac/scanners/terraform/... ./pkg/iac/terraform/... ./pkg/mapfs/...` — all green.
- Verified downstream against `cloud-custodian/tfparse` at the current pin: `test_funcs` goes from failing the value comparison outright to matching every expectation, and the suite is 23 passed / 1 failed, where the remaining failure is a local-environment artifact (a dangling `/etc/extlinux.conf` symlink on the test host makes `fileset("/etc/", "*")` abort on `fs.Stat`) unrelated to this change.

Worth sending upstream as well — the `else { target = mapfs.New() }` branch zeroes the filesystem for any library embedder, not just this fork.