### PR TITLE
fix: skip fileset matches that do not resolve to a file

### DIFF
--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
@@ -288,6 +288,22 @@ func MakeFileSetFunc(target fs.FS, baseDir string) function.Function {
 				fi, err := fs.Stat(useTarget, match)
 
 				if err != nil {
+					// The glob just matched this name, so a not-exist result means
+					// it does not resolve to a file: a dangling symlink, or an
+					// entry removed between the glob and the stat. That is simply
+					// not a regular file, so skip it the same way as below.
+					//
+					// Terraform errors out here instead, but it globs a workspace
+					// the user owns and surfaces the failure to them. This is a
+					// scanner walking trees it does not control, where the error
+					// is swallowed into a null and silently drops every resource
+					// keyed off the result -- one broken link should not erase the
+					// readable files beside it.
+					//
+					// Any other stat error (permissions, I/O) is still fatal.
+					if errors.Is(err, fs.ErrNotExist) {
+						continue
+					}
 					return cty.UnknownVal(cty.Set(cty.String)), fmt.Errorf("failed to stat (%s): %s", match, err)
 				}
 

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
@@ -1,12 +1,15 @@
 package funcs
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestExpandHome(t *testing.T) {
@@ -102,4 +105,51 @@ func TestVolumeRoot(t *testing.T) {
 			assert.False(t, filepath.IsAbs(rel), "%q should be relative to %q", rel, root)
 		})
 	}
+}
+
+func TestMakeFileSetFunc_DanglingSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Creating a symlink on Windows needs elevation or developer mode.
+		t.Skip("symlink creation is privileged on Windows")
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.yml"), []byte("name: real"), 0o600))
+	// A glob will match this name, but stat cannot resolve it.
+	require.NoError(t, os.Symlink(filepath.Join(dir, "nowhere", "gone.yml"), filepath.Join(dir, "broken.yml")))
+
+	fn := MakeFileSetFunc(os.DirFS(dir), ".")
+	val, err := fn.Call([]cty.Value{cty.StringVal("."), cty.StringVal("*.yml")})
+
+	// One unresolvable entry must not discard the readable ones: the result
+	// feeds for_each downstream, where an error becomes a null and silently
+	// drops every resource keyed off it.
+	require.NoError(t, err)
+	assert.Equal(t, cty.SetVal([]cty.Value{cty.StringVal("real.yml")}), val)
+}
+
+// statErrFS matches one name in a glob but fails to stat it with a non
+// not-exist error, which must stay fatal rather than being skipped.
+type statErrFS struct{ fs.FS }
+
+func (s statErrFS) Stat(name string) (fs.FileInfo, error) {
+	if filepath.Base(name) == "guarded.yml" {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrPermission}
+	}
+	return fs.Stat(s.FS, name)
+}
+
+func TestMakeFileSetFunc_StatErrorStaysFatal(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.yml"), []byte("name: real"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "guarded.yml"), []byte("name: guarded"), 0o600))
+
+	fn := MakeFileSetFunc(statErrFS{os.DirFS(dir)}, ".")
+	_, err := fn.Call([]cty.Value{cty.StringVal("."), cty.StringVal("*.yml")})
+
+	// The wrapped error is formatted with %s rather than %w upstream, so match
+	// on the message rather than the chain.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to stat (guarded.yml)")
+	assert.Contains(t, err.Error(), "permission denied")
 }


### PR DESCRIPTION
## Problem

`fileset()` aborts the entire call when `fs.Stat` fails on any single glob match:

```go
fi, err := fs.Stat(useTarget, match)
if err != nil {
    return cty.UnknownVal(cty.Set(cty.String)), fmt.Errorf("failed to stat (%s): %s", match, err)
}
if !fi.Mode().IsRegular() {
    continue
}
```

A dangling symlink is enough to trigger it, and the error never reaches the user — it becomes a null. A `for_each` keyed off that null expands to nothing, so every resource under it silently leaves the graph.

## Impact

Found while investigating a `fileset("/etc/", "*")` failure downstream: one dangling symlink on the scan host (`/etc/extlinux.conf`) nulled the whole call. Reduced to one broken link beside one perfectly readable file:

```hcl
locals {
  found   = fileset("${path.module}/data", "*.yml")   # real.yml + broken.yml (dangling)
  configs = { for f in local.found : f => yamldecode(file("${path.module}/data/${f}")) }
}

resource "aws_s3_bucket" "this" {
  for_each = local.configs
  bucket   = each.value.name
}
```

Through [cloud-custodian/tfparse](https://github.com/cloud-custodian/tfparse):

| | `fileset` result | buckets in graph |
| --- | --- | --- |
| before | `None` | 0 |
| after | `['real.yml']` | 1 (`real`) |

`real.yml` was readable throughout; it is collateral. For a scanner this is the worst shape of failure — zero findings and full compliance are indistinguishable, and it is easy to hit in a real repository: a symlink to a gitignored build artifact, an unchecked-out submodule, a stale `node_modules` link.

## Fix

A name the glob just matched that stats as not-existing does not resolve to a file — a dangling symlink, or an entry removed between the glob and the stat. That is exactly the "not a regular file" case skipped immediately below, so skip it there too.

**On diverging from Terraform.** Terraform errors here as well (still true on its `main`, and on v1.9), so this is deliberate. The difference is context: Terraform globs a workspace the user owns and *surfaces* the failure — `plan` fails loudly and they fix the link. This is a scanner walking trees it does not control, where the same failure is swallowed into a null and costs every sibling file.

The divergence is narrowed to `fs.ErrNotExist` only. Permission and I/O errors stay fatal, since those are real problems rather than an entry that simply is not there. That distinction earns its keep immediately: after this change the original `/etc` case still fails on the same host, now on `grub2-efi.cfg: permission denied` — a different entry and a genuine error the fix correctly refuses to paper over.

## Testing

- `TestMakeFileSetFunc_DanglingSymlink` — a broken link beside a readable file returns just the readable one. Skipped on Windows, where symlink creation is privileged.
- `TestMakeFileSetFunc_StatErrorStaysFatal` — a filesystem returning `fs.ErrPermission` still aborts, guarding the narrow half of the rule.

Both written failing first. `./pkg/iac/scanners/terraform/...`, `./pkg/iac/terraform/...` and `./pkg/mapfs/...` are green, `GOOS=windows go vet` clean, `gofmt` clean.

Validated end to end against tfparse via a local `replace`: full suite 24 passed, plus the reproduction above.